### PR TITLE
fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ function App() {
       <h6>Country</h6>
       <select
         onChange={(e) => {
-          setCountryid(e.id);
-          GetState(e.id).then((result) => {
+          const selectedID = parseInt(e.target.value)
+          setCountryid(selectedID);
+          GetState(selectedID).then((result) => {
             setStateList(result);
           });
         }}


### PR DESCRIPTION
In the custom example, the GetState function was not working as stated in the documentation because it was not getting any value (e.id). However, I made a correction by changing it to the correct value, which is e.value.target.
